### PR TITLE
Add OPENAI_API_KEY loader

### DIFF
--- a/md_batch_gpt/config.py
+++ b/md_batch_gpt/config.py
@@ -1,0 +1,8 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if not OPENAI_API_KEY:
+    raise RuntimeError("OPENAI_API_KEY not found in environment or .env file")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,36 @@
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+def import_config():
+    if 'md_batch_gpt.config' in importlib.sys.modules:
+        del importlib.sys.modules['md_batch_gpt.config']
+    return importlib.import_module('md_batch_gpt.config')
+
+
+def test_api_key_from_env(monkeypatch):
+    monkeypatch.setenv('OPENAI_API_KEY', 'from-env')
+    config = import_config()
+    assert config.OPENAI_API_KEY == 'from-env'
+
+
+def test_api_key_from_dotenv(monkeypatch, tmp_path):
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    env_file = Path('.env')
+    env_file.write_text('OPENAI_API_KEY=from-file')
+    try:
+        config = import_config()
+        assert config.OPENAI_API_KEY == 'from-file'
+    finally:
+        env_file.unlink()
+
+
+def test_missing_api_key(monkeypatch):
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    env_file = Path('.env')
+    if env_file.exists():
+        env_file.unlink()
+    with pytest.raises(RuntimeError):
+        import_config()


### PR DESCRIPTION
## Summary
- implement md_batch_gpt.config to load OPENAI_API_KEY from env or `.env`
- test loading key from both sources and error case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6875db35322c8326a3cd01c3c0664d7f