### PR TITLE
Add markdown utilities

### DIFF
--- a/md_batch_gpt/file_io.py
+++ b/md_batch_gpt/file_io.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+import os
+from typing import Iterator
+
+
+def iter_markdown_files(folder: Path) -> Iterator[Path]:
+    """Yield paths to Markdown files under *folder* skipping dotfiles."""
+    folder = Path(folder)
+    for path in folder.rglob("*.md"):
+        # Skip any file or directory that starts with a dot
+        relative_parts = path.relative_to(folder).parts
+        if any(part.startswith(".") for part in relative_parts):
+            continue
+        yield path
+
+
+def write_atomic(path: Path, data: str) -> None:
+    """Atomically write *data* to *path* using a temporary file."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as tmp:
+        tmp.write(data)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp_name = tmp.name
+    os.replace(tmp_name, path)

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from md_batch_gpt.file_io import iter_markdown_files, write_atomic
+
+
+def test_iter_markdown_files(tmp_path: Path):
+    (tmp_path / "a.md").write_text("a")
+    (tmp_path / "b.txt").write_text("b")
+    (tmp_path / ".hidden.md").write_text("hidden")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "c.md").write_text("c")
+    hidden_dir = tmp_path / ".hidden"
+    hidden_dir.mkdir()
+    (hidden_dir / "d.md").write_text("d")
+
+    results = sorted(p.relative_to(tmp_path) for p in iter_markdown_files(tmp_path))
+    assert results == [Path("a.md"), Path("sub/c.md")]
+
+
+def test_write_atomic(tmp_path: Path):
+    target = tmp_path / "file.txt"
+    write_atomic(target, "first")
+    assert target.read_text() == "first"
+    write_atomic(target, "second")
+    assert target.read_text() == "second"
+    # ensure no temporary files remain
+    files = list(tmp_path.iterdir())
+    assert files == [target]


### PR DESCRIPTION
## Summary
- add `iter_markdown_files` and `write_atomic` helpers
- test markdown file discovery and atomic writes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6875ddd55fec8326a6884442ad483afd