### PR TITLE
Add orchestrator and tests

### DIFF
--- a/md_batch_gpt/orchestrator.py
+++ b/md_batch_gpt/orchestrator.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from .file_io import iter_markdown_files, write_atomic
+from .openai_client import send_prompt
+
+
+def process_folder(folder: Path, prompt_paths: List[Path], model: str, temp: float) -> None:
+    """Process Markdown files in *folder* using prompts from *prompt_paths*."""
+    for md_file in iter_markdown_files(folder):
+        text = md_file.read_text()
+        for p in prompt_paths:
+            prompt = Path(p).read_text()
+            text = send_prompt(prompt, text, model, temp)
+            write_atomic(md_file, text)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import importlib
+
+
+def import_orchestrator():
+    if 'md_batch_gpt.orchestrator' in importlib.sys.modules:
+        del importlib.sys.modules['md_batch_gpt.orchestrator']
+    return importlib.import_module('md_batch_gpt.orchestrator')
+
+
+def test_process_folder(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv('OPENAI_API_KEY', 'dummy')
+    orch = import_orchestrator()
+
+    calls = []
+
+    def fake_send_prompt(prompt: str, content: str, model: str, temp: float) -> str:
+        calls.append((prompt, content, model, temp))
+        return f"{content}[{prompt}]"
+
+    monkeypatch.setattr(orch, 'send_prompt', fake_send_prompt)
+
+    (tmp_path / 'a.md').write_text('A')
+    sub = tmp_path / 'sub'
+    sub.mkdir()
+    (sub / 'b.md').write_text('B')
+    (tmp_path / '.hidden.md').write_text('hidden')
+
+    p1 = tmp_path / 'p1.txt'
+    p1.write_text('p1')
+    p2 = tmp_path / 'p2.txt'
+    p2.write_text('p2')
+
+    orch.process_folder(tmp_path, [p1, p2], model='m', temp=0.5)
+
+    assert (tmp_path / 'a.md').read_text() == 'A[p1][p2]'
+    assert (sub / 'b.md').read_text() == 'B[p1][p2]'
+    assert (tmp_path / '.hidden.md').read_text() == 'hidden'
+    assert len(calls) == 4
+    assert all(call[2:] == ('m', 0.5) for call in calls)


### PR DESCRIPTION
## Summary
- add `process_folder` in new `orchestrator` module
- unit test for orchestrator
- install runtime dependencies during tests

## Testing
- `pip install openai -q`
- `pip install python-dotenv -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6875df6c2434832698cf2da158130e0f