### PR TITLE
Improve README with install and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
 # md-batch-gpt
 
 Poetry-managed Python 3.11 project.
+
+## Installation
+
+Install the project's dependencies using Poetry:
+
+```bash
+poetry install
+```
+
+## Usage
+
+Run the batch processor against the `docs` folder using the provided prompts:
+
+```bash
+poetry run mdgpt run --input-dir docs --prompts prompts/first.txt prompts/second.txt
+```
+
+## .env Setup
+
+The application requires an OpenAI API key. Create a `.env` file in the project
+root containing:
+
+```bash
+OPENAI_API_KEY=<your-api-key>
+```
+
+Alternatively, set `OPENAI_API_KEY` in your shell environment before running
+the commands above.


### PR DESCRIPTION
## Summary
- document installation and usage
- note OpenAI API key setup in `.env`

## Testing
- `pip install -q openai==1.95.1 python-dotenv==1.1.1 typer==0.16.0`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6875e3ce58708326a723d1f5bc2ca97e