### PR TITLE
Add extra tests for file I/O utilities

### DIFF
--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -27,3 +27,10 @@ def test_write_atomic(tmp_path: Path):
     # ensure no temporary files remain
     files = list(tmp_path.iterdir())
     assert files == [target]
+
+
+def test_write_atomic_creates_parents(tmp_path: Path):
+    nested_target = tmp_path / "subdir" / "nested" / "file.txt"
+    write_atomic(nested_target, "content")
+    assert nested_target.read_text() == "content"
+    assert (tmp_path / "subdir" / "nested").is_dir()


### PR DESCRIPTION
## Summary
- expand `tests/test_file_io.py` with an extra check that `write_atomic` creates parent directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6875e4d8f940832682adaa67e95cf541