### PR TITLE
Run black formatter

### DIFF
--- a/md_batch_gpt/cli.py
+++ b/md_batch_gpt/cli.py
@@ -18,7 +18,9 @@ def run(
     ),
     model: str = typer.Option("o3", "--model", help="OpenAI model to use"),
     temp: float = typer.Option(0.2, "--temp", help="Sampling temperature"),
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose output"),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Enable verbose output"
+    ),
 ) -> None:
     """Run the batch processor on *folder* using *prompts*."""
     if verbose:

--- a/md_batch_gpt/file_io.py
+++ b/md_batch_gpt/file_io.py
@@ -21,7 +21,9 @@ def write_atomic(path: Path, data: str) -> None:
     """Atomically write *data* to *path* using a temporary file."""
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    with NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as tmp:
+    with NamedTemporaryFile(
+        "w", encoding="utf-8", dir=path.parent, delete=False
+    ) as tmp:
         tmp.write(data)
         tmp.flush()
         os.fsync(tmp.fileno())

--- a/md_batch_gpt/openai_client.py
+++ b/md_batch_gpt/openai_client.py
@@ -1,4 +1,5 @@
 """OpenAI chat completion client utilities."""
+
 from __future__ import annotations
 
 from typing import Iterable
@@ -30,7 +31,7 @@ def _chat_request(messages: Iterable[dict], model: str, temperature: float):
             if exc.status_code not in {429, 502}:
                 raise
         if attempt < 2:
-            time.sleep(2 ** attempt)
+            time.sleep(2**attempt)
     # If we fall through, raise the last captured exception
     if last_exc:
         raise last_exc

--- a/md_batch_gpt/orchestrator.py
+++ b/md_batch_gpt/orchestrator.py
@@ -7,7 +7,9 @@ from .file_io import iter_markdown_files, write_atomic
 from .openai_client import send_prompt
 
 
-def process_folder(folder: Path, prompt_paths: List[Path], model: str, temp: float) -> None:
+def process_folder(
+    folder: Path, prompt_paths: List[Path], model: str, temp: float
+) -> None:
     """Process Markdown files in *folder* using prompts from *prompt_paths*."""
     for md_file in iter_markdown_files(folder):
         text = md_file.read_text()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,31 +5,31 @@ import pytest
 
 
 def import_config():
-    if 'md_batch_gpt.config' in importlib.sys.modules:
-        del importlib.sys.modules['md_batch_gpt.config']
-    return importlib.import_module('md_batch_gpt.config')
+    if "md_batch_gpt.config" in importlib.sys.modules:
+        del importlib.sys.modules["md_batch_gpt.config"]
+    return importlib.import_module("md_batch_gpt.config")
 
 
 def test_api_key_from_env(monkeypatch):
-    monkeypatch.setenv('OPENAI_API_KEY', 'from-env')
+    monkeypatch.setenv("OPENAI_API_KEY", "from-env")
     config = import_config()
-    assert config.OPENAI_API_KEY == 'from-env'
+    assert config.OPENAI_API_KEY == "from-env"
 
 
 def test_api_key_from_dotenv(monkeypatch, tmp_path):
-    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
-    env_file = Path('.env')
-    env_file.write_text('OPENAI_API_KEY=from-file')
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    env_file = Path(".env")
+    env_file.write_text("OPENAI_API_KEY=from-file")
     try:
         config = import_config()
-        assert config.OPENAI_API_KEY == 'from-file'
+        assert config.OPENAI_API_KEY == "from-file"
     finally:
         env_file.unlink()
 
 
 def test_missing_api_key(monkeypatch):
-    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
-    env_file = Path('.env')
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    env_file = Path(".env")
     if env_file.exists():
         env_file.unlink()
     with pytest.raises(RuntimeError):

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -4,13 +4,13 @@ import importlib
 
 
 def import_orchestrator():
-    if 'md_batch_gpt.orchestrator' in importlib.sys.modules:
-        del importlib.sys.modules['md_batch_gpt.orchestrator']
-    return importlib.import_module('md_batch_gpt.orchestrator')
+    if "md_batch_gpt.orchestrator" in importlib.sys.modules:
+        del importlib.sys.modules["md_batch_gpt.orchestrator"]
+    return importlib.import_module("md_batch_gpt.orchestrator")
 
 
 def test_process_folder(monkeypatch, tmp_path: Path):
-    monkeypatch.setenv('OPENAI_API_KEY', 'dummy')
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     orch = import_orchestrator()
 
     calls = []
@@ -19,23 +19,23 @@ def test_process_folder(monkeypatch, tmp_path: Path):
         calls.append((prompt, content, model, temp))
         return f"{content}[{prompt}]"
 
-    monkeypatch.setattr(orch, 'send_prompt', fake_send_prompt)
+    monkeypatch.setattr(orch, "send_prompt", fake_send_prompt)
 
-    (tmp_path / 'a.md').write_text('A')
-    sub = tmp_path / 'sub'
+    (tmp_path / "a.md").write_text("A")
+    sub = tmp_path / "sub"
     sub.mkdir()
-    (sub / 'b.md').write_text('B')
-    (tmp_path / '.hidden.md').write_text('hidden')
+    (sub / "b.md").write_text("B")
+    (tmp_path / ".hidden.md").write_text("hidden")
 
-    p1 = tmp_path / 'p1.txt'
-    p1.write_text('p1')
-    p2 = tmp_path / 'p2.txt'
-    p2.write_text('p2')
+    p1 = tmp_path / "p1.txt"
+    p1.write_text("p1")
+    p2 = tmp_path / "p2.txt"
+    p2.write_text("p2")
 
-    orch.process_folder(tmp_path, [p1, p2], model='m', temp=0.5)
+    orch.process_folder(tmp_path, [p1, p2], model="m", temp=0.5)
 
-    assert (tmp_path / 'a.md').read_text() == 'A[p1][p2]'
-    assert (sub / 'b.md').read_text() == 'B[p1][p2]'
-    assert (tmp_path / '.hidden.md').read_text() == 'hidden'
+    assert (tmp_path / "a.md").read_text() == "A[p1][p2]"
+    assert (sub / "b.md").read_text() == "B[p1][p2]"
+    assert (tmp_path / ".hidden.md").read_text() == "hidden"
     assert len(calls) == 4
-    assert all(call[2:] == ('m', 0.5) for call in calls)
+    assert all(call[2:] == ("m", 0.5) for call in calls)


### PR DESCRIPTION
## Summary
- run `black` on source and tests for consistent formatting

## Testing
- `black --line-length 88 md_batch_gpt/*.py tests/*.py`
- `black --line-length 88 README.md pyproject.toml` *(fails: Cannot parse)*

------
https://chatgpt.com/codex/tasks/task_b_6875e5972b6c832696bffe329fd5b566