### PR TITLE
Add dry run option

### DIFF
--- a/md_batch_gpt/cli.py
+++ b/md_batch_gpt/cli.py
@@ -29,13 +29,18 @@ def run(
     verbose: bool = typer.Option(
         False, "--verbose", "-v", help="Enable verbose output"
     ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="List files to be processed without sending prompts",
+    ),
 ) -> None:
     """Run the batch processor on *folder* using *prompts*."""
     if verbose:
         typer.echo(f"Folder: {folder}")
         typer.echo(f"Prompts: {', '.join(str(p) for p in prompts)}")
         typer.echo(f"Model: {model} Temperature: {temp}")
-    process_folder(folder, list(prompts), model=model, temp=temp)
+    process_folder(folder, list(prompts), model=model, temp=temp, dry_run=dry_run)
     if verbose:
         typer.echo("Done")
 

--- a/md_batch_gpt/orchestrator.py
+++ b/md_batch_gpt/orchestrator.py
@@ -8,11 +8,22 @@ from .openai_client import send_prompt
 
 
 def process_folder(
-    folder: Path, prompt_paths: List[Path], model: str, temp: float
+    folder: Path, prompt_paths: List[Path], model: str, temp: float, dry_run: bool = False
 ) -> None:
-    """Process Markdown files in *folder* using prompts from *prompt_paths*."""
+    """Process Markdown files in *folder* using prompts from *prompt_paths*.
+
+    When *dry_run* is True, print the files that would be processed and the
+    number of prompts, but make no changes.
+    """
     prompts = [Path(p).read_text() for p in prompt_paths]
-    for md_file in iter_markdown_files(folder):
+    files = list(iter_markdown_files(folder))
+    if dry_run:
+        for f in files:
+            print(f)
+        print(f"Prompt count: {len(prompts)}")
+        return
+
+    for md_file in files:
         text = md_file.read_text()
         for prompt in prompts:
             text = send_prompt(prompt, text, model, temp)


### PR DESCRIPTION
## Summary
- add `--dry-run` support to CLI
- support dry run mode in `process_folder`
- test that dry run avoids openai and filesystem writes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6875e838212c8326843037393b0e1610