### PR TITLE
Ensure utf-8 encoding in read_text

### DIFF
--- a/md_batch_gpt/file_io.py
+++ b/md_batch_gpt/file_io.py
@@ -6,6 +6,12 @@ import os
 from typing import Iterator
 
 
+def read_text(path: Path) -> str:
+    """Return the contents of *path* as UTF-8 text."""
+    path = Path(path)
+    return path.read_text(encoding="utf-8")
+
+
 def iter_markdown_files(folder: Path) -> Iterator[Path]:
     """Yield paths to Markdown files under *folder* skipping dotfiles."""
     folder = Path(folder)


### PR DESCRIPTION
## Summary
- add a helper function to read files using UTF-8
- keep atomic write using UTF-8

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6875ec479a7c832690176537b2496b55