### PR TITLE
Add max_tokens option for OpenAI prompts

### DIFF
--- a/md_batch_gpt/cli.py
+++ b/md_batch_gpt/cli.py
@@ -26,6 +26,7 @@ def run(
     ),
     model: str = typer.Option("o3", "--model", help="OpenAI model to use"),
     temp: float = typer.Option(0.2, "--temp", help="Sampling temperature"),
+    max_tokens: int | None = typer.Option(None, "--max-tokens", help="Max tokens for completion"),
     verbose: bool = typer.Option(
         False, "--verbose", "-v", help="Enable verbose output"
     ),
@@ -39,12 +40,13 @@ def run(
     if verbose:
         typer.echo(f"Folder: {folder}")
         typer.echo(f"Prompts: {', '.join(str(p) for p in prompts)}")
-        typer.echo(f"Model: {model} Temperature: {temp}")
+        typer.echo(f"Model: {model} Temperature: {temp} Max tokens: {max_tokens}")
     process_folder(
         folder,
         list(prompts),
         model=model,
         temp=temp,
+        max_tokens=max_tokens,
         dry_run=dry_run,
         verbose=verbose,
     )

--- a/md_batch_gpt/orchestrator.py
+++ b/md_batch_gpt/orchestrator.py
@@ -13,6 +13,7 @@ def process_folder(
     prompt_paths: List[Path],
     model: str,
     temp: float,
+    max_tokens: int | None = None,
     dry_run: bool = False,
     verbose: bool = False,
 ) -> None:
@@ -34,5 +35,5 @@ def process_folder(
         for idx, prompt in enumerate(prompts):
             if verbose:
                 typer.echo(f"{md_file}: pass {idx+1}/{len(prompts)}")
-            text = send_prompt(prompt, text, model, temp)
+            text = send_prompt(prompt, text, model, temp, max_tokens)
             write_atomic(md_file, text)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,3 +47,49 @@ def test_run_dry_run(monkeypatch, tmp_path: Path):
     assert "a.md" in result.stdout
     assert "b.md" in result.stdout
     assert "Prompt count: 2" in result.stdout
+
+
+def test_run_max_tokens(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+
+    original_option = typer.Option
+
+    def fake_option(*args, **kwargs):
+        kwargs.pop("nargs", None)
+        return original_option(*args, **kwargs)
+
+    monkeypatch.setattr(typer, "Option", fake_option)
+
+    cli = import_cli()
+
+    captured = {}
+
+    def fake_process_folder(
+        folder: Path,
+        prompt_paths: list[Path],
+        model: str,
+        temp: float,
+        max_tokens: int | None = None,
+        dry_run: bool = False,
+        verbose: bool = False,
+    ) -> None:
+        captured["max_tokens"] = max_tokens
+
+    monkeypatch.setattr(cli, "process_folder", fake_process_folder)
+
+    (tmp_path / "a.md").write_text("A")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        [
+            str(tmp_path),
+            "--prompts",
+            "tests/data/p1.txt",
+            "--max-tokens",
+            "123",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert captured["max_tokens"] == 123


### PR DESCRIPTION
## Summary
- extend `openai_client.send_prompt` with optional `max_tokens`
- plumb `max_tokens` through the orchestrator and CLI
- add CLI option `--max-tokens`
- test coverage for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6875f505434483269e4c0925192be049