### PR TITLE
Apply automatic formatting and clean up tests

### DIFF
--- a/md_batch_gpt/cli.py
+++ b/md_batch_gpt/cli.py
@@ -26,7 +26,6 @@ def run(
         ...,
         "--prompts",
         help="Space-separated list of prompt files",
-        nargs=-1,
         callback=validate_prompts,
     ),
     model: str = typer.Option("o3", "--model", help="OpenAI model to use"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
 import importlib
 from pathlib import Path
 
-import typer
 from typer.testing import CliRunner
 
 
@@ -13,14 +12,6 @@ def import_cli():
 
 def test_run_dry_run(monkeypatch, tmp_path: Path):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
-
-    original_option = typer.Option
-
-    def fake_option(*args, **kwargs):
-        kwargs.pop("nargs", None)
-        return original_option(*args, **kwargs)
-
-    monkeypatch.setattr(typer, "Option", fake_option)
 
     cli = import_cli()
     monkeypatch.setattr("md_batch_gpt.orchestrator.send_prompt", lambda *a, **k: "")
@@ -51,14 +42,6 @@ def test_run_dry_run(monkeypatch, tmp_path: Path):
 
 def test_run_max_tokens(monkeypatch, tmp_path: Path):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
-
-    original_option = typer.Option
-
-    def fake_option(*args, **kwargs):
-        kwargs.pop("nargs", None)
-        return original_option(*args, **kwargs)
-
-    monkeypatch.setattr(typer, "Option", fake_option)
 
     cli = import_cli()
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -99,8 +99,8 @@ def test_process_folder_verbose(monkeypatch, tmp_path: Path, capsys):
     orch.process_folder(tmp_path, [p1, p2], model="m", temp=0.5, verbose=True)
 
     out_lines = capsys.readouterr().out.splitlines()
-    assert f"a.md: pass 1/2" in out_lines[0]
-    assert f"a.md: pass 2/2" in out_lines[1]
+    assert "a.md: pass 1/2" in out_lines[0]
+    assert "a.md: pass 2/2" in out_lines[1]
 
 
 def test_process_folder_max_tokens(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## Summary
- run formatters across the repo
- drop obsolete monkey-patch in `tests/test_cli.py`
- remove `nargs` from CLI option
- update assertions in `test_orchestrator`

## Testing
- `ruff format .`
- `ruff check --fix .`
- `black .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6875f9707df48326a7041ec765eb708b