### PR TITLE
feat(cli): auto-detect multiple prompt files for N-pass workflow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# Documentation
+
+## Usage
+
+If --prompts is omitted, the tool will run one pass for every *.txt file in prompts/, ordered alphabetically (e.g. 01_*.txt, 02_*.txt, …).

--- a/md_batch_gpt/cli.py
+++ b/md_batch_gpt/cli.py
@@ -23,7 +23,7 @@ app = typer.Typer()
 def run(
     folder: Path = typer.Argument(..., exists=True, file_okay=False, dir_okay=True),
     prompts: List[Path] = typer.Option(
-        ...,
+        [],
         "--prompts",
         help="Space-separated list of prompt files",
         callback=validate_prompts,
@@ -43,13 +43,26 @@ def run(
     ),
 ) -> None:
     """Run the batch processor on *folder* using *prompts*."""
+    prompt_list = list(prompts)
+    if len(prompt_list) == 0:
+        default_dir = Path(__file__).parent.parent / "prompts"
+        prompt_paths = sorted(default_dir.glob("*.txt"))
+        if not prompt_paths:
+            raise typer.BadParameter(
+                f"No prompt files found in {default_dir}. "
+                "Pass --prompts explicitly or add *.txt files."
+            )
+        prompt_list = list(prompt_paths)
+
     if verbose:
         typer.echo(f"Folder: {folder}")
-        typer.echo(f"Prompts: {', '.join(str(p) for p in prompts)}")
-        typer.echo(f"Model: {model} Temperature: {temp} Max tokens: {max_tokens}")
+        typer.echo(f"Prompts: {', '.join(str(p) for p in prompt_list)}")
+        typer.echo(
+            f"Model: {model} Temperature: {temp} Max tokens: {max_tokens}"
+        )
     process_folder(
         folder,
-        list(prompts),
+        prompt_list,
         model=model,
         temp=temp,
         max_tokens=max_tokens,


### PR DESCRIPTION
## Summary
- allow running `mdgpt run` without specifying `--prompts`
- auto-discover all `*.txt` files under `prompts/`
- document default discovery behaviour
- test CLI auto-discovery of multiple prompts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6875ff4dd4fc83268517f6c575f16bbb