### PR TITLE
Fix encoding when reading prompts

### DIFF
--- a/md_batch_gpt/orchestrator.py
+++ b/md_batch_gpt/orchestrator.py
@@ -22,7 +22,7 @@ def process_folder(
     When *dry_run* is True, print the files that would be processed and the
     number of prompts, but make no changes.
     """
-    prompts = [Path(p).read_text() for p in prompt_paths]
+    prompts = [Path(p).read_text(encoding="utf-8", errors="replace") for p in prompt_paths]
     files = list(iter_markdown_files(folder))
     if dry_run:
         for f in files:


### PR DESCRIPTION
## Summary
- ensure prompts are read with utf-8 encoding

## Testing
- `poetry install`
- `poetry run mdgpt docs --dry-run --verbose` *(fails: OPENAI_API_KEY not found)*

------
https://chatgpt.com/codex/tasks/task_b_68760594908483269c8938af08769b79