### PR TITLE
Fix default temp usage

### DIFF
--- a/md_batch_gpt/cli.py
+++ b/md_batch_gpt/cli.py
@@ -29,7 +29,6 @@ def run(
         callback=validate_prompts,
     ),
     model: str = typer.Option("o3", "--model", help="OpenAI model to use"),
-    temp: float = typer.Option(0.2, "--temp", help="Sampling temperature"),
     max_tokens: int | None = typer.Option(
         None, "--max-tokens", help="Max tokens for completion"
     ),
@@ -57,14 +56,11 @@ def run(
     if verbose:
         typer.echo(f"Folder: {folder}")
         typer.echo(f"Prompts: {', '.join(str(p) for p in prompt_list)}")
-        typer.echo(
-            f"Model: {model} Temperature: {temp} Max tokens: {max_tokens}"
-        )
+        typer.echo(f"Model: {model} Max tokens: {max_tokens}")
     process_folder(
         folder,
         prompt_list,
         model=model,
-        temp=temp,
         max_tokens=max_tokens,
         dry_run=dry_run,
         verbose=verbose,

--- a/md_batch_gpt/openai_client.py
+++ b/md_batch_gpt/openai_client.py
@@ -47,13 +47,12 @@ def _chat_request(
 def send_prompt(
     prompt: str,
     content: str,
-    model: str = "o3",
-    temp: float = 0.2,
-    max_tokens: int | None = None,
+    model: str,
+    max_tokens: int | None,
 ) -> str:
     """Send `content` with a system `prompt` and return the assistant message text."""
     messages = [
         {"role": "system", "content": prompt},
         {"role": "user", "content": content},
     ]
-    return _chat_request(messages, model=model, temperature=temp, max_tokens=max_tokens)
+    return _chat_request(messages, model=model, temperature=1, max_tokens=max_tokens)

--- a/md_batch_gpt/orchestrator.py
+++ b/md_batch_gpt/orchestrator.py
@@ -12,7 +12,6 @@ def process_folder(
     folder: Path,
     prompt_paths: List[Path],
     model: str,
-    temp: float,
     max_tokens: int | None = None,
     dry_run: bool = False,
     verbose: bool = False,
@@ -35,5 +34,5 @@ def process_folder(
         for idx, prompt in enumerate(prompts):
             if verbose:
                 typer.echo(f"{md_file}: pass {idx + 1}/{len(prompts)}")
-            text = send_prompt(prompt, text, model, temp, max_tokens)
+            text = send_prompt(prompt, text, model, max_tokens)
             write_atomic(md_file, text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ mdgpt = "md_batch_gpt.cli:app"
 
 [tool.md_batch_gpt]
 model = "o3"
-temperature = 0.2
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,7 +51,6 @@ def test_run_max_tokens(monkeypatch, tmp_path: Path):
         folder: Path,
         prompt_paths: list[Path],
         model: str,
-        temp: float,
         max_tokens: int | None = None,
         dry_run: bool = False,
         verbose: bool = False,

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -19,10 +19,9 @@ def test_process_folder(monkeypatch, tmp_path: Path):
         prompt: str,
         content: str,
         model: str,
-        temp: float,
         max_tokens: int | None = None,
     ) -> str:
-        calls.append((prompt, content, model, temp, max_tokens))
+        calls.append((prompt, content, model, max_tokens))
         return f"{content}[{prompt}]"
 
     monkeypatch.setattr(orch, "send_prompt", fake_send_prompt)
@@ -38,13 +37,13 @@ def test_process_folder(monkeypatch, tmp_path: Path):
     p2 = tmp_path / "p2.txt"
     p2.write_text("p2")
 
-    orch.process_folder(tmp_path, [p1, p2], model="m", temp=0.5)
+    orch.process_folder(tmp_path, [p1, p2], model="m")
 
     assert (tmp_path / "a.md").read_text() == "A[p1][p2]"
     assert (sub / "b.md").read_text() == "B[p1][p2]"
     assert (tmp_path / ".hidden.md").read_text() == "hidden"
     assert len(calls) == 4
-    assert all(call[2:] == ("m", 0.5, None) for call in calls)
+    assert all(call[2:] == ("m", None) for call in calls)
 
 
 def test_process_folder_dry_run(monkeypatch, tmp_path: Path, capsys):
@@ -63,7 +62,7 @@ def test_process_folder_dry_run(monkeypatch, tmp_path: Path, capsys):
     p1 = tmp_path / "p1.txt"
     p1.write_text("p1")
 
-    orch.process_folder(tmp_path, [p1], model="m", temp=0.5, dry_run=True)
+    orch.process_folder(tmp_path, [p1], model="m", dry_run=True)
 
     assert send_calls == []
     assert write_calls == []
@@ -81,7 +80,6 @@ def test_process_folder_verbose(monkeypatch, tmp_path: Path, capsys):
         prompt: str,
         content: str,
         model: str,
-        temp: float,
         max_tokens: int | None = None,
     ) -> str:
         return f"{content}[{prompt}]"
@@ -96,7 +94,7 @@ def test_process_folder_verbose(monkeypatch, tmp_path: Path, capsys):
     p2 = tmp_path / "p2.txt"
     p2.write_text("p2")
 
-    orch.process_folder(tmp_path, [p1, p2], model="m", temp=0.5, verbose=True)
+    orch.process_folder(tmp_path, [p1, p2], model="m", verbose=True)
 
     out_lines = capsys.readouterr().out.splitlines()
     assert "a.md: pass 1/2" in out_lines[0]
@@ -113,7 +111,6 @@ def test_process_folder_max_tokens(monkeypatch, tmp_path: Path):
         prompt: str,
         content: str,
         model: str,
-        temp: float,
         max_tokens: int | None = None,
     ) -> str:
         captured["max_tokens"] = max_tokens
@@ -125,6 +122,6 @@ def test_process_folder_max_tokens(monkeypatch, tmp_path: Path):
     p = tmp_path / "p.txt"
     p.write_text("p")
 
-    orch.process_folder(tmp_path, [p], model="m", temp=0.5, max_tokens=99)
+    orch.process_folder(tmp_path, [p], model="m", max_tokens=99)
 
     assert captured["max_tokens"] == 99


### PR DESCRIPTION
## Summary
- drop `--temp` option from the CLI
- hard-code temperature=1 in `send_prompt`
- remove `temperature` config entry
- update orchestrator and tests for new API

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6876094915188326b45e6a1252285fea