### PR TITLE
Fix CLI example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ poetry install
 Run the batch processor against the `docs` folder using the provided prompts:
 
 ```bash
-poetry run mdgpt run --input-dir docs --prompts prompts/first.txt prompts/second.txt
+poetry run mdgpt run docs --prompts prompts/first.txt prompts/second.txt
 ```
 
 ## .env Setup


### PR DESCRIPTION
## Summary
- update CLI usage example to show docs as a positional argument

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68787b2ae6448326ba114fbb1845505b